### PR TITLE
Make PDO decorator extends PDO

### DIFF
--- a/src/Fabfuel/Prophiler/Decorator/PDO/PDO.php
+++ b/src/Fabfuel/Prophiler/Decorator/PDO/PDO.php
@@ -13,7 +13,7 @@ use Fabfuel\Prophiler\ProfilerInterface;
  * @pattern decorator
  * @mixin \PDOStatement
  */
-class PDO
+class PDO extends \PDO
 {
     /**
      * @var \PDO


### PR DESCRIPTION
This would allow the decorator to be injected to replace the original PDO object without breaking typehinting.

```
public function myMethod(\PDO $pdo) {

}
```