### PR TITLE
Update db plugin to require generic abstract db adapter

### DIFF
--- a/src/Fabfuel/Prophiler/Plugin/Phalcon/Db/AdapterPlugin.php
+++ b/src/Fabfuel/Prophiler/Plugin/Phalcon/Db/AdapterPlugin.php
@@ -8,7 +8,7 @@ namespace Fabfuel\Prophiler\Plugin\Phalcon\Db;
 use Fabfuel\Prophiler\Benchmark\BenchmarkInterface;
 use Fabfuel\Prophiler\Plugin\PluginAbstract;
 use Phalcon\Events\Event;
-use Phalcon\Db\Adapter;
+use Phalcon\Db\Adapter\AbstractAdapter as Adapter;
 
 /**
  * Class AdapterPlugin


### PR DESCRIPTION
Phalcon 4 compatibility

Fixes the following error:

TypeError: Argument 2 passed to Fabfuel\Prophiler\Plugin\Phalcon\Db\AdapterPlugin::beforeQuery() must be an instance of Phalcon\Db\Adapter, instance of Phalcon\Db\Adapter\Pdo\Mysql given

Once fixed the toolbar seems to be functioning fine when initialised as follows:

```
$profiler = new \Fabfuel\Prophiler\Profiler();
$di->setShared('profiler', $profiler);

$profiler->addAggregator(new \Fabfuel\Prophiler\Aggregator\Database\QueryAggregator());
$profiler->addAggregator(new \Fabfuel\Prophiler\Aggregator\Cache\CacheAggregator());

$pluginManager = new \Fabfuel\Prophiler\Plugin\Manager\Phalcon($profiler);
$pluginManager->register();
```


![image](https://user-images.githubusercontent.com/1327332/92083334-c94ba080-edbd-11ea-9b2d-31739af7bda3.png)

Queries are being logged, request info is available and timeline/memory/etc are being displayed. Not a full compatibility test but seems to be mostly working.